### PR TITLE
Update Invoke-ApiMethod.ps1

### DIFF
--- a/PoshSonarrRadarr/Private/Invoke-ApiMethod.ps1
+++ b/PoshSonarrRadarr/Private/Invoke-ApiMethod.ps1
@@ -48,7 +48,12 @@ function Invoke-ApiMethod {
             $ResultObject = [ordered] @{
                 StatusCode        = $Result.StatusCode
                 StatusDescription = $Result.StatusDescription
-                Content           = $Result.Content | ConvertFrom-Json | Select-Object -ExpandProperty $ExpandJsonProperty | Write-Output
+            }
+            if ($null -eq $ExpandJsonProperty) {
+                $ResultObject["Content"] = $Result.Content | ConvertFrom-Json
+            }
+            else {
+                $ResultObject["Content"] = $Result.Content | ConvertFrom-Json | Select-Object -ExpandProperty $ExpandJsonProperty | Write-Output
             }
         }
         catch {


### PR DESCRIPTION
Optionally return `$ExpandJsonProperty`, e.g. with `Invoke-SonarrDownloadedEpisodeScan` the `-ExpandJsonProperty` parameter is not used so it's blank within this function. This stops me from getting the command ID in the return from the API call using the Sonarr API method `DownloadedEpisodesScan`.